### PR TITLE
Added more interface and basic Pinhole example

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,5 +1,3 @@
-# This file is machine-generated - editing it directly is not advised
-
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
@@ -24,11 +22,11 @@ deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
 [[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
+deps = ["LinearAlgebra", "Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[InteractiveUtils]]
-deps = ["Markdown"]
+deps = ["LinearAlgebra", "Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[LibGit2]]
@@ -52,7 +50,7 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [[Printf]]
@@ -69,9 +67,9 @@ uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[Rotations]]
 deps = ["LinearAlgebra", "StaticArrays", "Statistics"]
-git-tree-sha1 = "4fa94411637e4f4ca4d9b5bfa64d7042541d67b3"
+git-tree-sha1 = "d5f83867093db7319a9366d55f29280ecae9bcda"
 uuid = "6038ab10-8711-5258-84ad-4b1120ba62dc"
-version = "0.12.0"
+version = "0.13.0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -105,7 +103,7 @@ deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[UUIDs]]
-deps = ["Random", "SHA"]
+deps = ["Random"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ julia = "^1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [targets]
-test = ["Test"]
+test = ["Test", "LinearAlgebra"]

--- a/src/CameraModels.jl
+++ b/src/CameraModels.jl
@@ -2,18 +2,70 @@ module CameraModels
 
 using StaticArrays, CoordinateTransformations
 
-export Ray, CameraModel, pixel2ray, point2pixel, Pinhole
+export Ray, CameraModel, PixelCoordinate, Vector3, Vector2, Point3
+export pixel2ray, point2pixel, canreproject, origin, direction, sensorsize, columns, rows, lookdirection, updirection
 
 const PixelCoordinate = SVector{2, Float64}
+const Vector2 = SVector{2, Float64}
+
 const Point3 = SVector{3, Float64}
-const Vector3 = Point3
+const Vector3 = SVector{3, Float64}
 
 abstract type CameraModel end
+
+origin3d = zeros(Point3)
 
 struct Ray
     origin::Point3
     direction::Vector3
 end
+
+"""
+    origin(ray)
+
+Return the direction of the ray as a (Vector3)
+"""
+function origin end
+
+origin(vector::Vector3) = origin3d
+origin(ray::Ray) = vector.origin
+
+
+"""
+    direction(ray)
+
+Return the origin of ray, typically just a zero $(Point3) for normal cameras.
+"""
+function direction end
+
+direction(vector::Vector3) = vector
+direction(ray::Ray) = vector.direction
+
+
+"""
+    columns(model::CameraModel)
+
+Returns the width of the camera sensor.
+"""
+function columns end
+
+"""
+    rows(model::CameraModel)
+
+Returns the height of the camera sensor.
+"""
+function rows end
+
+"""
+    sensorsize(model::CameraModel)
+
+Return the size of the camera sensor. By default calling out to columns(model) and rows(model) to build an SVector{2}
+
+`sensorsize(cameramodel::CameraModel) = SVector{2}(columns(cameramodel), rows(cameramodel))`
+"""
+function sensorsize end
+
+sensorsize(cameramodel::CameraModel) = SVector{2}(columns(cameramodel), rows(cameramodel))
 
 """
     pixel2ray(cameramodel::CameraModel, pixelcoordinate::$(PixelCoordinate))
@@ -29,32 +81,27 @@ Returns the pixel location onto which the 3D coordinate `pointincamera` is proje
 """
 function point2pixel end
 
+"""
+    lookdirection(camera::CameraModel)
 
-
-struct Pinhole <: CameraModel
-    prinicipalpoint::Tuple{Float64, Float64} # in pixels
-    focallength::Tuple{Float64, Float64} # in pixels
-    skewcoefficient::Float64
-end
+Return the lookdirection of this camera model.
+"""
+function lookdirection end
 
 """
-    point2pixel(m::PinHole)
-Return a transformation that converts real-world coordinates
-to camera coordinates. This currently ignores any tangential 
-distortion between the lens and the image plane.
+    updirection(camera::CameraModel)
+
+Return the updirection of this camera model.
 """
-point2pixel(m::Pinhole) = cameramap(m.intrinsic.focallength, m.intrinsic.prinicipalpoint) ∘ inv(AffineMap(RotXYZ(m.extrinsic.direction...), m.extrinsic.location))
+function updirection end
 
-# TODO: Also implement pixel2ray for PinHole
+"""
+    canreproject(camera::CameraModel)
 
-# MORE IDEAS:
-# - Something like CoordinateTransformations' transform_deriv / transform_deriv_params, will be useful for estimators
-# - Could a camera model BE a CoordinateTransformations.Transform ?
-# - In doubt if pixel2ray/point2pixel should return a transform or DO the transform... The former will lead to ugly code, I find...
-# - I don't like the Ray struct... For many users, all rays will have zero origin anyways. I'm in accurate underwater and 360 business,
-#   where the shift of the origin matters. I'll be extending this later with some very exotic camera models, which will need something
-#   like this. Needs some more thought... 
-#   --> Maybe a pixel2rayorigin, which defaults to calling to the "simple" pixel2ray and adding a default zero origin. When you do the
-#       accurate stuff, you would call pixel2rayorigin rather then pixel2ray. And only the funky models would have to implement it.    
+Confirms if point2pixel is implemented for this camera model.
+"""
+canreproject(camera::CameraModel) = true
+
+include("Pinhole.jl")
 
 end # module

--- a/src/Pinhole.jl
+++ b/src/Pinhole.jl
@@ -1,12 +1,14 @@
 
 export Pinhole
 
-struct Pinhole{C,R} <: CameraModel where C where Return
+struct Pinhole <: CameraModel
     
-    Pinhole(pixelwidth::Int, pixelheight::Int, prinicipalpoint::PixelCoordinate, focallength::Vector2) = new{pixelwidth, pixelheight}(prinicipalpoint, focallength)
+    Pinhole(pixelwidth::Int, pixelheight::Int, prinicipalpoint::PixelCoordinate, focallength::Vector2) = new(prinicipalpoint, focallength, pixelwidth, pixelheight)
 
     prinicipalpoint::PixelCoordinate # in pixels
     focallength::Vector2 # in pixels
+    columns::Int
+    rows::Int
 end
 
 """
@@ -38,5 +40,5 @@ end
 lookdirection(cameramodel::Pinhole) = SVector{3}(0,1,0)
 updirection(cameramodel::Pinhole) = SVector{3}(0,0,1)
 
-columns(cameramodel::Pinhole{NColumns, NRows}) where NColumns where NRows = NColumns 
-rows(cameramodel::Pinhole{NColumns, NRows}) where NColumns where NRows = NRows 
+columns(cameramodel::Pinhole) = cameramodel.columns
+rows(cameramodel::Pinhole) = cameramodel.rows 

--- a/src/Pinhole.jl
+++ b/src/Pinhole.jl
@@ -1,0 +1,42 @@
+
+export Pinhole
+
+struct Pinhole{C,R} <: CameraModel where C where Return
+    
+    Pinhole(pixelwidth::Int, pixelheight::Int, prinicipalpoint::PixelCoordinate, focallength::Vector2) = new{pixelwidth, pixelheight}(prinicipalpoint, focallength)
+
+    prinicipalpoint::PixelCoordinate # in pixels
+    focallength::Vector2 # in pixels
+end
+
+"""
+    point2pixel(model::Pinhole, pointincamera::$(Point3))
+
+Return a transformation that converts real-world coordinates
+to camera coordinates. This currently ignores any tangential 
+distortion between the lens and the image plane.
+"""
+function point2pixel(model::Pinhole, pointincamera::Point3)
+    column = model.prinicipalpoint[1] + model.focallength[1] * pointincamera[1] / pointincamera[2]
+    row = model.prinicipalpoint[2] - model.focallength[2] * pointincamera[3] / pointincamera[2]
+    return PixelCoordinate(column, row)
+end
+
+"""
+    pixel2ray(model::Pinhole, pixelcoordinate::$(PixelCoordinate))
+
+Return a transformation that converts real-world coordinates
+to camera coordinates. This currently ignores any tangential 
+distortion between the lens and the image plane.
+"""
+function pixel2ray(model::Pinhole, pixelcoordinate::PixelCoordinate)
+    x = (pixelcoordinate[1] - model.prinicipalpoint[1]) / model.focallength[1]
+    z = -(pixelcoordinate[2] - model.prinicipalpoint[2]) / model.focallength[2]
+    return Vector3(x, 1, z)
+end
+
+lookdirection(cameramodel::Pinhole) = SVector{3}(0,1,0)
+updirection(cameramodel::Pinhole) = SVector{3}(0,0,1)
+
+columns(cameramodel::Pinhole{NColumns, NRows}) where NColumns where NRows = NColumns 
+rows(cameramodel::Pinhole{NColumns, NRows}) where NColumns where NRows = NRows 

--- a/test/CameraModelTestBench.jl
+++ b/test/CameraModelTestBench.jl
@@ -1,0 +1,40 @@
+using LinearAlgebra
+
+function run_test_bench(model::C, pixel_accuracy::Float64 = 1e-5, ray_accuracy::Float64 = 1e-4) where C <: CameraModel
+
+    @testset "Check basics and interface implementation for $(C)." begin
+
+        forward = lookdirection(model)
+        up = updirection(model)
+        right = cross(forward, up)
+
+        @testset "Test model axes" begin
+            @test norm(forward) ≈ 1.0 
+            @test norm(up) ≈ 1.0 
+            @test norm(right)  ≈ 1.0
+        end
+
+        pixelsize = sensorsize(model)
+
+        # Get a pixel location somewhere near the image centre.
+        image_centre = (pixelsize .+ 1) ./ 2
+        slight_offset = 0.042 .* pixelsize
+        some_pixel_location = image_centre + slight_offset
+
+        # Get the ray that belongs to that pixel.
+        ray = pixel2ray(model, some_pixel_location)
+        
+        # Generate a 3D point along that ray.
+        point = origin(ray) + 4.2 .* direction(ray)
+
+        # Some models might not implement point2pixel.
+        if canreproject(model)
+            reprojection = point2pixel(model, point)
+            @test some_pixel_location ≈ reprojection atol = pixel_accuracy
+        else 
+            @info "point2pixel not implemented for $(C)."
+        end
+
+    end
+
+end

--- a/test/Pinhole.jl
+++ b/test/Pinhole.jl
@@ -1,0 +1,17 @@
+principal_point = PixelCoordinate(55.4, 49.6)
+focal_length = Vector2(61.2, 66.4)
+
+model = Pinhole(100, 100, principal_point, focal_length)
+
+run_test_bench(model)
+
+@testset "Check specifics for Pinhole model." begin
+    some_point = Point3(0, 1, 0)
+    should_be_principal_point = point2pixel(model, some_point)
+    @test principal_point ≈ should_be_principal_point
+
+    ray = pixel2ray(model, principal_point)
+    @test direction(ray) ≈ Vector3(0,1,0)
+    @test origin(ray) ≈ Point3(0,0,0)
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,19 @@
 using CameraModels
 using Test
+using StaticArrays
 
-@testset "real to camera" begin
-    intrinsic = Intrinsic((0., 0.), (1., 0), 0.0)
-    extrinsic = Extrinsic([0., 0, 0], [1., 0, 0])
-    m = Pinhole(intrinsic, extrinsic)
-    f = real2pixel(m)
-    @test f([0,0,1]) == [0, 0]
+struct SomeTestModel <: CameraModel end
+
+@testset "Test sensorsize using rows and columns." begin
+    CameraModels.rows(m::SomeTestModel) = 11
+    CameraModels.columns(m::SomeTestModel) = 22
+    
+    model = SomeTestModel()
+    @test sensorsize(model) == SVector{2}(22,11)
 end
+
+
+
+include("CameraModelTestBench.jl")
+
+include("Pinhole.jl")


### PR DESCRIPTION
Baby steps...

Simplified the Pinhole model, and defined more stuff like an interface. Nothing is enforced in julia, so I created a sort of rudimentary test-bench where future camera model can be run through, so you'll get some basic checks for free and know if you implemented all that is expected.

Like before, very open for major changes and different points of view. I commented in the PR from 1 month ago about the extrinsic.

Not entirely happy with "lookdirection" and "updirection" - I don't want to pin down the fact that all Pinholes have Y as the look direction and Z as the up. Allowing to pick arbitrary vectors combined with any model, would make the basic projection function overly complex. So now it is the other way around, you implement a model and overload what is considered look-direction and up-direction. But many many people consider the Z-axis or -Z axis as the look direction. It would be great to enable everybody to keep working in his/her own preferred camera reference system...

